### PR TITLE
Fixing access of transport method

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/transport"
 )
 
 var (
@@ -59,12 +58,10 @@ type handler struct {
 // It is invoked like any gRPC server stream and uses the gRPC server framing to get and receive bytes from the wire,
 // forwarding it to a ClientStream established against the relevant ClientConn.
 func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error {
-	// little bit of gRPC internals never hurt anyone
-	lowLevelServerStream, ok := transport.StreamFromContext(serverStream.Context())
+	fullMethodName, ok := grpc.MethodFromServerStream(serverStream) 
 	if !ok {
-		return grpc.Errorf(codes.Internal, "lowLevelServerStream not exists in context")
+		return grpc.Errorf(codes.Internal, "failed to get method from server stream")
 	}
-	fullMethodName := lowLevelServerStream.Method()
 	// We require that the director's returned context inherits from the serverStream.Context().
 	outgoingCtx, backendConn, err := s.director(serverStream.Context(), fullMethodName)
 	clientCtx, clientCancel := context.WithCancel(outgoingCtx)


### PR DESCRIPTION
gRPC project removed the function used to get the transport from the context. They added a better public function to do the same thing.