### PR TITLE
Fix Issue 24

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/transport"
 )
 
 var (
@@ -59,12 +58,12 @@ type handler struct {
 // It is invoked like any gRPC server stream and uses the gRPC server framing to get and receive bytes from the wire,
 // forwarding it to a ClientStream established against the relevant ClientConn.
 func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error {
-	// little bit of gRPC internals never hurt anyone
-	lowLevelServerStream, ok := transport.StreamFromContext(serverStream.Context())
+
+	fullMethodName, ok := grpc.MethodFromServerStream(serverStream)
 	if !ok {
-		return grpc.Errorf(codes.Internal, "lowLevelServerStream not exists in context")
+		return grpc.Errorf(codes.Internal, "could not extract method name from serverStream")
 	}
-	fullMethodName := lowLevelServerStream.Method()
+
 	// We require that the director's returned context inherits from the serverStream.Context().
 	outgoingCtx, backendConn, err := s.director(serverStream.Context(), fullMethodName)
 	clientCtx, clientCancel := context.WithCancel(outgoingCtx)


### PR DESCRIPTION
This change addresses: https://github.com/mwitkow/grpc-proxy/issues/24

There was a change in the upstream gRPC project that broke the API used by the `proxy` package. https://github.com/grpc/grpc-go/commit/57640c0e6fd5e562b3a53f6b72738759165c80e1

A new way to get the method name from stream has been amde by the upstream project via https://github.com/grpc/grpc-go/pull/1588

