### PR TITLE
Change anypb.Any to emptypb.Empty (thanks @danw for the fix)

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 var (
@@ -112,7 +113,7 @@ func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error
 func (s *handler) forwardClientToServer(src grpc.ClientStream, dst grpc.ServerStream) chan error {
 	ret := make(chan error, 1)
 	go func() {
-		f := &anypb.Any{}
+		f := &emptypb.Empty{}
 		for i := 0; ; i++ {
 			if err := src.RecvMsg(f); err != nil {
 				ret <- err // this can be io.EOF which is happy case


### PR DESCRIPTION
This fixes a issue that was picked up in some of my own unit tests for a separate project. Thanks danw for the workaround. I don't know for sure if this will cause problems for other people, but it got it all working perfectly in my use cases. 

https://github.com/mwitkow/grpc-proxy/issues/55#issuecomment-1059557772