### PR TITLE
Add support for Client Connection Interface

### DIFF
--- a/proxy/director.go
+++ b/proxy/director.go
@@ -5,6 +5,7 @@ package proxy
 
 import (
 	"context"
+
 	"google.golang.org/grpc"
 )
 
@@ -21,4 +22,4 @@ import (
 // are invoked. So decisions around authorization, monitoring etc. are better to be handled there.
 //
 // See the rather rich example.
-type StreamDirector func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error)
+type StreamDirector func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error)

--- a/proxy/examples_test.go
+++ b/proxy/examples_test.go
@@ -46,7 +46,7 @@ func ExampleTransparentHandler() {
 // Provides a simple example of a director that shields internal services and dials a staging or production backend.
 // This is a *very naive* implementation that creates a new connection on every request. Consider using pooling.
 func ExampleStreamDirector() {
-	director = func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
+	director = func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
 		// Make sure we never forward internal services.
 		if strings.HasPrefix(fullMethodName, "/com.example.internal.") {
 			return nil, nil, status.Errorf(codes.Unimplemented, "Unknown method")

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -70,7 +70,7 @@ func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error
 	clientCtx, clientCancel := context.WithCancel(outgoingCtx)
 	defer clientCancel()
 	// TODO(mwitkow): Add a `forwarded` header to metadata, https://en.wikipedia.org/wiki/X-Forwarded-For.
-	clientStream, err := grpc.NewClientStream(clientCtx, clientStreamDescForProxying, backendConn, fullMethodName)
+	clientStream, err := backendConn.NewStream(clientCtx, clientStreamDescForProxying, fullMethodName)
 	if err != nil {
 		return err
 	}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -200,7 +200,7 @@ func (s *ProxyHappySuite) SetupSuite() {
 	//lint:ignore SA1019 regression test
 	s.serverClientConn, err = grpc.Dial(s.serverListener.Addr().String(), grpc.WithInsecure(), grpc.WithCodec(proxy.Codec()))
 	require.NoError(s.T(), err, "must not error on deferred client Dial")
-	director := func(ctx context.Context, fullName string) (context.Context, *grpc.ClientConn, error) {
+	director := func(ctx context.Context, fullName string) (context.Context, grpc.ClientConnInterface, error) {
 		md, ok := metadata.FromIncomingContext(ctx)
 		if ok {
 			if _, exists := md[rejectingMdKey]; exists {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -11,21 +11,21 @@ import (
 )
 
 // NewProxy sets up a simple proxy that forwards all requests to dst.
-func NewProxy(dst *grpc.ClientConn, opts ...grpc.ServerOption) *grpc.Server {
+func NewProxy(dst grpc.ClientConnInterface, opts ...grpc.ServerOption) *grpc.Server {
 	opts = append(opts, DefaultProxyOpt(dst))
 	// Set up the proxy server and then serve from it like in step one.
 	return grpc.NewServer(opts...)
 }
 
 // DefaultProxyOpt returns an grpc.UnknownServiceHandler with a DefaultDirector.
-func DefaultProxyOpt(cc *grpc.ClientConn) grpc.ServerOption {
+func DefaultProxyOpt(cc grpc.ClientConnInterface) grpc.ServerOption {
 	return grpc.UnknownServiceHandler(TransparentHandler(DefaultDirector(cc)))
 }
 
 // DefaultDirector returns a very simple forwarding StreamDirector that forwards all
 // calls.
-func DefaultDirector(cc *grpc.ClientConn) StreamDirector {
-	return func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
+func DefaultDirector(cc grpc.ClientConnInterface) StreamDirector {
+	return func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
 		md, _ := metadata.FromIncomingContext(ctx)
 		ctx = metadata.NewOutgoingContext(ctx, md.Copy())
 		return ctx, cc, nil

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -38,7 +38,7 @@ func TestLegacyBehaviour(t *testing.T) {
 	// 2.
 	go func() {
 		// Second, we need to implement the SteamDirector.
-		directorFn := func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
+		directorFn := func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
 			md, _ := metadata.FromIncomingContext(ctx)
 			outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
 			return outCtx, testCC, nil

--- a/testservice/testping.go
+++ b/testservice/testping.go
@@ -99,7 +99,7 @@ func TestTestServiceServerImpl(t *testing.T, client TestServiceClient) {
 			}
 			res, err := stream.Recv()
 			if err != nil {
-				t.Errorf("receiving full duplex stream: %w", err)
+				t.Errorf("receiving full duplex stream: %v", err)
 				return
 			}
 			t.Logf("got %v (%d)", res.Value, res.Counter)


### PR DESCRIPTION
Add support to work with generic `grpc.ClientConnInterface` types