### PR TITLE
feat: support of grpc.ClientConnInterface allows custom streams

### DIFF
--- a/proxy/director.go
+++ b/proxy/director.go
@@ -22,3 +22,11 @@ import (
 //
 // See the rather rich example.
 type StreamDirector func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error)
+
+type StreamDirectorI func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error)
+
+func toStreamDirectorI(director StreamDirector) StreamDirectorI {
+	return func(ctx context.Context, fullMethodName string) (context.Context, grpc.ClientConnInterface, error) {
+		return director(ctx, fullMethodName)
+	}
+}


### PR DESCRIPTION
This makes StreamDirector function to accept grpc.ClientConnInterface instead of strict *grpc.ClientConn implementation. This allows to use custom connection implementations and stubs, like inprocess stream channeling without real network connection (https://pkg.go.dev/github.com/fullstorydev/grpchan/inprocgrpc)

I added the changed version interfaces to make this changes backwards-compatible.
Maybe it is woth of releasing another version of grpc-proxy package, that is not compatible with previous one on interface level.

If we just change StreamDirector declaration, all implementations of StreamDirector will become incompatible with the new interface :(