### PR TITLE
Add TransparentHandlerWithOptions function

### DIFF
--- a/testservice/testping.go
+++ b/testservice/testping.go
@@ -99,7 +99,7 @@ func TestTestServiceServerImpl(t *testing.T, client TestServiceClient) {
 			}
 			res, err := stream.Recv()
 			if err != nil {
-				t.Errorf("receiving full duplex stream: %w", err)
+				t.Errorf("receiving full duplex stream: %v", err)
 				return
 			}
 			t.Logf("got %v (%d)", res.Value, res.Counter)


### PR DESCRIPTION
Prior to this function being added, it was not possible to set gRPC CallOptions on the call to `grpc.NewClientStream(...)` performed by the TransparentHandler.

Notably, the `grpc.MaxRecvMsgSize()` would not be configured and would result in errors if the payload size was exceeded, despite the fact that the proxy's server had the value correctly configured.

The introduction of this `TransparentHandlerWithOptions(...)` function allows for various settings to be configured on the handler and passed through to the `grpc.NewClientStream(...)` call.